### PR TITLE
Add Bard field object to meta data

### DIFF
--- a/src/Mutator.php
+++ b/src/Mutator.php
@@ -30,7 +30,9 @@ class Mutator
         $this->extensions = $extensions;
 
         Augmentor::addExtensions([
-            'bmuRoot' => new Nodes\Root(),
+            'bmuRoot' => function ($bard) {
+                return new Nodes\Root(['bard' => $bard]);
+            },
             'bmuHtml' => new Nodes\Html(),
         ]);
     }
@@ -45,7 +47,7 @@ class Mutator
         return $value;
     }
 
-    public function processRoot($data)
+    public function processRoot($data, array $extra)
     {
         if (in_array($data, $this->roots, true)) {
             return;
@@ -53,8 +55,8 @@ class Mutator
 
         $this->roots[] = $data;
 
-        Data::walk($data, function ($data, $meta) {
-            $this->storeMeta($data, $meta);
+        Data::walk($data, function ($data, $meta) use ($extra) {
+            $this->storeMeta($data, array_merge($meta, $extra));
             $this->mutateData($data->type, $data);
         });
     }

--- a/src/Mutator.php
+++ b/src/Mutator.php
@@ -31,7 +31,7 @@ class Mutator
 
         Augmentor::addExtensions([
             'bmuRoot' => function ($bard) {
-                return new Nodes\Root(['bard' => $bard]);
+                return new Nodes\Root(['bard' => $bard->field()]);
             },
             'bmuHtml' => new Nodes\Html(),
         ]);

--- a/src/Nodes/Root.php
+++ b/src/Nodes/Root.php
@@ -8,9 +8,18 @@ class Root extends \Tiptap\Core\Node
 {
     public static $name = 'bmuRoot';
 
+    public function addOptions()
+    {
+        return [
+            'bard' => null,
+        ];
+    }
+
     public function renderHTML($node, $HTMLAttributes = [])
     {
-        Mutator::processRoot($node);
+        Mutator::processRoot($node, [
+            'bard' => $this->options['bard'],
+        ]);
 
         return null;
     }


### PR DESCRIPTION
Adds the Bard fieldtype object to the metadata, eg:

```php
Mutator::html('heading', function ($value, $data, $meta) {
    $meta['bard'] // Field object
    $meta['bard']->handle() // Field handle
    $meta['bard']->get('display') // Field config value
    $meta['bard']->parent() // Parent entry object
});
```