### PR TITLE
Add docs example to wrap headings

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -129,6 +129,22 @@ Mutator::html('paragraph', function ($value, $data) {
 });
 ```
 
+### Wrap all heading text with permalink anchors and add a class
+
+```php
+use JackSleight\StatamicBardMutator\Facades\Mutator;
+
+Mutator::html('heading', function ($value, $data) {
+    $slug = str_slug(collect($data->content)->implode('text', ''));
+    $value[2] = ['a', [
+        'id' => $slug,
+        'href' => '#'.$slug,
+        'class' => 'hover:underline',
+    ], 0];
+    return $value;
+});
+```
+
 ## Data Mutators
 
 ### Add permalink anchors before all headings
@@ -147,21 +163,6 @@ Mutator::data('heading', function ($data) {
 ```
 
 Check out the modifier [example below](examples#using-with-the-bard-modifiers) to see how you could use these in a table of contents.
-
-### Wrap all headings with permalink anchors and add a class
-
-```php
-use JackSleight\StatamicBardMutator\Facades\Mutator;
-use JackSleight\StatamicBardMutator\Support\Data;
-
-Mutator::data('heading', function ($data) {
-    $slug = str_slug(collect($data->content)->implode('text', ''));
-    $content = collect($data->content)->implode('text', '');
-    $data->content[0] = Data::html(
-        '<a id="'.$slug.'" href="#'.$slug.'" class="hover:underline">'.$content.'</a>'
-    );
-});
-```
 
 ## Using with the Bard modifiers
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -131,7 +131,7 @@ Mutator::html('paragraph', function ($value, $data) {
 
 ## Data Mutators
 
-### Add permalink anchors to all headings
+### Add permalink anchors before all headings
 
 ```php
 use JackSleight\StatamicBardMutator\Facades\Mutator;
@@ -147,6 +147,21 @@ Mutator::data('heading', function ($data) {
 ```
 
 Check out the modifier [example below](examples#using-with-the-bard-modifiers) to see how you could use these in a table of contents.
+
+### Wrap all headings with permalink anchors and add a class
+
+```php
+use JackSleight\StatamicBardMutator\Facades\Mutator;
+use JackSleight\StatamicBardMutator\Support\Data;
+
+Mutator::data('heading', function ($data) {
+    $slug = str_slug(collect($data->content)->implode('text', ''));
+    $content = collect($data->content)->implode('text', '');
+    $data->content[0] = Data::html(
+        '<a id="'.$slug.'" href="#'.$slug.'" class="hover:underline">'.$content.'</a>'
+    );
+});
+```
 
 ## Using with the Bard modifiers
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -147,7 +147,7 @@ Mutator::html('heading', function ($value, $data) {
 
 ## Data Mutators
 
-### Add permalink anchors before all headings
+### Add permalink anchors before all heading text
 
 ```php
 use JackSleight\StatamicBardMutator\Facades\Mutator;


### PR DESCRIPTION
This is a slight variation of the example given in the docs: [Add permalink anchors to all headings](https://jacksleight.dev/docs/bard-mutator/examples#add-permalink-anchors-to-all-headings).

This new example:
- _Wraps_ the headings in an anchor (rather than _preceding_ with a `#`)
- Adds a class to the anchor

Thanks to @chriship who wrote the PHP.